### PR TITLE
fix for tile objects with empty name

### DIFF
--- a/src/level/TMXObjectGroup.js
+++ b/src/level/TMXObjectGroup.js
@@ -328,8 +328,8 @@
             // get the corresponding tile into our object
             this.image = tileset.getTileImage(tmxTile);
 
-            // set a generic name if not defined
-            if (typeof (this.name) === "undefined") {
+            // set a generic name if not defined or the empty string
+            if (!this.name) {
                 this.name = "TileObject";
             }
         },


### PR DESCRIPTION
In Tiled 0.11.0 (at least) creating a new tile object sets its name to "", not undefined
